### PR TITLE
Fix 2 options issues and add ability to send a config object to query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ class SequelizeSoftDelete {
    */
   softDelete (Model, options) {
     const defaultOptions = { field: 'deleted', deleted: true }
-    const deletedOptions = { ...options, ...defaultOptions }
+    const deletedOptions = { ...defaultOptions, ...options }
     /**
      * soft delete
      * Set deleted to true

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ class SequelizeSoftDelete {
      */
     const updateDeleted = async function (options, config) {
       const docs = await Model.update(
-        { [deletedOptions.deleted]: deletedOptions.deleted },
+        { [deletedOptions.field]: deletedOptions.deleted },
         options,
         config
       )

--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,11 @@ class SequelizeSoftDelete {
      * @param {Object} options Options to filter query
      * @return {Number} Total updated
      */
-    const updateDeleted = async function (options) {
+    const updateDeleted = async function (options, config) {
       const docs = await Model.update(
-        { deleted: deletedOptions.deleted },
-        options
+        { [deletedOptions.deleted]: deletedOptions.deleted },
+        options,
+        config
       )
       return docs.length
     }


### PR DESCRIPTION
- fixed an issue where options being overridden by default options.
- fixed an issue where a user can't set delete field name.

- a user now able to pass config to Sequalize update query like `transaction`

